### PR TITLE
refactor: colores de etiquetas de eventos via mapa SCSS

### DIFF
--- a/criptadoge-app/src/renderer/src/components/EventCalendar/EventCalendar.tsx
+++ b/criptadoge-app/src/renderer/src/components/EventCalendar/EventCalendar.tsx
@@ -9,16 +9,7 @@ import { useNavigate } from 'react-router-dom'
 import styles from './EventCalendar.module.scss'
 import { EventMaker } from '../EventMaker/EventMaker'
 import { useEvents } from '../../hooks/useEvents'
-import { AppEvent } from '../../data/events'
-
-const LABEL_COLORS: Record<string, string> = {
-  'Magic: The Gathering': '#173d8d',
-  'Yu-Gi-Oh!': '#eab308',
-  'Pokémon TCG': '#ec4899',
-  'Juegos de Mesa': '#10b981',
-  'Rol / D&D': '#ef4444',
-  'Otro': '#94a3b8'
-}
+import { AppEvent, LABEL_COLORS } from '../../data/events'
 
 const FILTER_LABELS = ['Todos', 'Magic: The Gathering', 'Yu-Gi-Oh!', 'Pokémon TCG', 'Juegos de Mesa', 'Rol / D&D']
 

--- a/criptadoge-app/src/renderer/src/components/EventList/EventList.module.scss
+++ b/criptadoge-app/src/renderer/src/components/EventList/EventList.module.scss
@@ -1,5 +1,6 @@
 @use '../../styles/variables' as v;
 @use '../../styles/mixins' as m;
+@use '../../styles/labels' as l;
 
 .container {
   padding: 2rem;
@@ -43,9 +44,16 @@
 
 .badge {
   @include m.badge-base;
-  background-color: rgba(v.$color-primary, 0.15);
-  color: v.$color-primary;
+  border: 1px solid transparent;
   display: inline-block;
+}
+
+@each $key, $clr in l.$label-colors {
+  .badge-#{$key} {
+    background-color: rgba($clr, 0.2);
+    border-color: $clr;
+    color: #f8fafc;
+  }
 }
 
 .description {

--- a/criptadoge-app/src/renderer/src/components/EventList/EventList.tsx
+++ b/criptadoge-app/src/renderer/src/components/EventList/EventList.tsx
@@ -4,6 +4,15 @@ import styles from './EventList.module.scss'
 import { EventMaker } from '../EventMaker/EventMaker'
 import { useEvents } from '../../hooks/useEvents'
 
+const LABEL_KEY: Record<string, string> = {
+  'Magic: The Gathering': 'magic',
+  'Yu-Gi-Oh!':           'yugioh',
+  'Pokémon TCG':         'pokemon',
+  'Juegos de Mesa':      'mesa',
+  'Rol / D&D':           'rol',
+  'Otro':                'otro'
+}
+
 export const EventList: React.FC = () => {
   const { events, isLoading, addEvent } = useEvents()
   const [isMakerOpen, setIsMakerOpen] = useState(false)
@@ -40,7 +49,9 @@ export const EventList: React.FC = () => {
               events.map((evt) => (
                 <tr key={evt.id}>
                   <td>
-                    <span className={styles.badge}>{evt.label}</span>
+                    <span className={`${styles.badge} ${styles[`badge-${LABEL_KEY[evt.label] ?? 'otro'}`]}`}>
+                      {evt.label}
+                    </span>
                   </td>
                   <td>
                     <strong>{evt.title}</strong>

--- a/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.module.scss
+++ b/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.module.scss
@@ -1,6 +1,7 @@
 @use '../../styles/variables' as v;
 @use 'sass:color';
 @use '../../styles/mixins' as m;
+@use '../../styles/labels' as l;
 
 @keyframes fadeIn {
   from {
@@ -90,11 +91,17 @@
   font-size: 0.85rem;
   font-family: v.$font-mono;
   font-weight: bold;
-  background: rgba(v.$color-primary, 0.2);
-  color: color.adjust(v.$color-primary, $lightness: 30%);
-  border: 1px solid v.$color-primary;
+  border: 1px solid transparent;
   text-transform: uppercase;
   letter-spacing: 1px;
+}
+
+@each $key, $clr in l.$label-colors {
+  .badge-#{$key} {
+    background-color: rgba($clr, 0.2);
+    border-color: $clr;
+    color: #f8fafc;
+  }
 }
 
 .dateTime {

--- a/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.tsx
+++ b/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.tsx
@@ -2,6 +2,15 @@ import React, { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getEventById, deleteEvent, updateEvent } from '../../api/eventsApi'
 import { AppEvent } from '../../data/events'
+
+const LABEL_KEY: Record<string, string> = {
+  'Magic: The Gathering': 'magic',
+  'Yu-Gi-Oh!':           'yugioh',
+  'Pokémon TCG':         'pokemon',
+  'Juegos de Mesa':      'mesa',
+  'Rol / D&D':           'rol',
+  'Otro':                'otro'
+}
 import styles from './EventProfile.module.scss'
 import { Modal } from '../Modal/Modal'
 import { EventMaker } from '../EventMaker/EventMaker'
@@ -61,7 +70,9 @@ export const EventProfile: React.FC = () => {
 
       <div className={styles.profileContainer}>
         <div className={styles.header}>
-          <span className={styles.badge}>{event.label}</span>
+          <span className={`${styles.badge} ${styles[`badge-${LABEL_KEY[event.label] ?? 'otro'}`]}`}>
+            {event.label}
+          </span>
           <h1>{event.title}</h1>
           <div className={styles.dateTime}>
             <span>Fecha ➡ {event.date}</span>

--- a/criptadoge-app/src/renderer/src/data/events.ts
+++ b/criptadoge-app/src/renderer/src/data/events.ts
@@ -1,5 +1,14 @@
 // src/data/events.ts
 
+export const LABEL_COLORS: Record<string, string> = {
+  'Magic: The Gathering': '#173d8d',
+  'Yu-Gi-Oh!': '#eab308',
+  'Pokémon TCG': '#ec4899',
+  'Juegos de Mesa': '#10b981',
+  'Rol / D&D': '#ef4444',
+  'Otro': '#94a3b8'
+}
+
 export interface AppEvent {
   id: string
   title: string

--- a/criptadoge-app/src/renderer/src/styles/_labels.scss
+++ b/criptadoge-app/src/renderer/src/styles/_labels.scss
@@ -1,0 +1,8 @@
+$label-colors: (
+  'magic':   #173d8d,
+  'yugioh':  #eab308,
+  'pokemon': #ec4899,
+  'mesa':    #10b981,
+  'rol':     #ef4444,
+  'otro':    #94a3b8
+);


### PR DESCRIPTION
- Extraído mapa de colores a styles/_labels.scss como fuente única
- EventList y EventProfile generan clases badge-* con @each en lugar de inline styles
- EventCalendar importa LABEL_COLORS desde data/events.ts (uso programático de FullCalendar)