### PR TITLE
fix: call a membresia

### DIFF
--- a/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.tsx
+++ b/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.tsx
@@ -89,7 +89,7 @@ export const MemberProfile: React.FC = () => {
     if (!member) return
     try {
       const { data } = await apiClient.put(`/usuarios/${member.id}/membresia`, {})
-      setMember(data)
+      setMember((prev) => ({ ...prev!, ...data }))
       setShowRenewModal(false)
     } catch (err) {
       alert('Error al intentar renovar al socio.')

--- a/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.tsx
+++ b/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.tsx
@@ -88,7 +88,7 @@ export const MemberProfile: React.FC = () => {
   const handleConfirmRenew = async () => {
     if (!member) return
     try {
-      const { data } = await apiClient.put(`/usuarios/${member.id}/membresia`)
+      const { data } = await apiClient.put(`/usuarios/${member.id}/membresia`, {})
       setMember(data)
       setShowRenewModal(false)
     } catch (err) {


### PR DESCRIPTION
El {} fuerza a Axios a incluir Content-Type: application/json en la request, que es lo que NestJS espera para procesar correctamente un PUT.