### PR TITLE
feat: añadir botón de ayuda y panel AppGuide con secciones de vídeo

### DIFF
--- a/criptadoge-app/src/renderer/src/components/AppGuide/AppGuide.module.scss
+++ b/criptadoge-app/src/renderer/src/components/AppGuide/AppGuide.module.scss
@@ -1,0 +1,124 @@
+@use '../../styles/variables' as v;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.panel {
+  background-color: v.$bg-card;
+  border: 1px solid v.$color-border;
+  border-top: 2px solid v.$color-accent;
+  border-radius: 10px;
+  width: 90%;
+  max-width: 800px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(v.$color-primary, 0.15);
+  animation: guideIn 0.2s ease-out forwards;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid v.$color-border;
+  flex-shrink: 0;
+}
+
+.title {
+  font-family: v.$font-title;
+  font-size: 1.4rem;
+  color: v.$text-main;
+  margin: 0;
+  letter-spacing: 1px;
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  color: v.$text-muted;
+  cursor: pointer;
+  padding: 0.4rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s, color 0.15s;
+
+  &:hover {
+    background-color: rgba(v.$color-error, 0.15);
+    color: v.$color-error;
+  }
+}
+
+.content {
+  overflow-y: auto;
+  padding: 1.5rem 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sectionTitle {
+  font-family: v.$font-main;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: v.$text-main;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.videoPlaceholder {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-color: v.$bg-main;
+  border: 1px solid v.$color-border;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 20px rgba(v.$color-primary, 0.08);
+}
+
+.videoPlaceholderText {
+  font-family: v.$font-mono;
+  font-size: 0.85rem;
+  color: v.$text-muted;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.sectionDescription {
+  font-family: v.$font-main;
+  font-size: 0.9rem;
+  color: v.$text-muted;
+  line-height: 1.6;
+  margin: 0;
+}
+
+@keyframes guideIn {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}

--- a/criptadoge-app/src/renderer/src/components/AppGuide/AppGuide.tsx
+++ b/criptadoge-app/src/renderer/src/components/AppGuide/AppGuide.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import styles from './AppGuide.module.scss'
+
+interface AppGuideProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const GUIDE_SECTIONS = [
+  {
+    title: 'Gestión de Socios',
+    description:
+      'Aprende a crear nuevos socios, editar sus datos, consultar su ficha completa y gestionar el estado de su membresía desde el panel de administración.'
+  },
+  {
+    title: 'Renovar una Membresía',
+    description:
+      'El socio debe tener un DNI registrado para poder renovar. Al confirmar, el sistema extiende la fecha de expiración un mes automáticamente y actualiza el estado a Activo.'
+  },
+  {
+    title: 'Crear y Gestionar Eventos',
+    description:
+      'Crea eventos con título, descripción, etiqueta de categoría, fecha y hora. Puedes editar o eliminar cualquier evento desde su ficha de detalle.'
+  },
+  {
+    title: 'Usar el Calendario',
+    description:
+      'El calendario muestra todos los eventos del sistema con sus colores de etiqueta. Puedes navegar por meses y hacer clic en cualquier evento para ver su detalle.'
+  }
+]
+
+export const AppGuide: React.FC<AppGuideProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.panel} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>GUÍA DE LA APLICACIÓN</h2>
+          <button className={styles.closeBtn} onClick={onClose} title="Cerrar">
+            <svg width="12" height="12" viewBox="0 0 12 12">
+              <line x1="0" y1="0" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" />
+              <line x1="12" y1="0" x2="0" y2="12" stroke="currentColor" strokeWidth="1.5" />
+            </svg>
+          </button>
+        </div>
+
+        <div className={styles.content}>
+          {GUIDE_SECTIONS.map((section) => (
+            <div key={section.title} className={styles.section}>
+              <h3 className={styles.sectionTitle}>{section.title}</h3>
+              <div className={styles.videoPlaceholder}>
+                <span className={styles.videoPlaceholderText}>Espacio para Vídeo</span>
+              </div>
+              <p className={styles.sectionDescription}>{section.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/criptadoge-app/src/renderer/src/components/TitleBar/TitleBar.module.scss
+++ b/criptadoge-app/src/renderer/src/components/TitleBar/TitleBar.module.scss
@@ -57,3 +57,17 @@
     color: v.$text-main;
   }
 }
+
+.helpBtn {
+  font-family: v.$font-main;
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: v.$text-muted;
+  border-right: 1px solid v.$color-border;
+  margin-right: 0.25rem;
+
+  &:hover {
+    background-color: rgba(v.$color-accent, 0.15);
+    color: v.$color-accent;
+  }
+}

--- a/criptadoge-app/src/renderer/src/components/TitleBar/TitleBar.tsx
+++ b/criptadoge-app/src/renderer/src/components/TitleBar/TitleBar.tsx
@@ -1,56 +1,67 @@
 import React, { useState, useEffect } from 'react'
 import styles from './TitleBar.module.scss'
+import { AppGuide } from '../AppGuide/AppGuide'
 
 export const TitleBar: React.FC = () => {
   const [isMaximized, setIsMaximized] = useState(false)
+  const [isGuideOpen, setIsGuideOpen] = useState(false)
 
   useEffect(() => {
     window.api.onMaximizeChange((value) => setIsMaximized(value))
   }, [])
 
   return (
-    <div className={styles.titlebar}>
-      <div className={styles.appInfo}>
-        <span className={styles.appName}>CRIPTA DEL DOGE</span>
-      </div>
-      <div className={styles.controls}>
-        <button
-          className={styles.controlBtn}
-          onClick={() => window.api.minimize()}
-          title="Minimizar"
-        >
-          <svg width="10" height="1" viewBox="0 0 10 1">
-            <rect width="10" height="1" fill="currentColor" />
-          </svg>
-        </button>
-        <button
-          className={styles.controlBtn}
-          onClick={() => window.api.maximize()}
-          title={isMaximized ? 'Restaurar' : 'Maximizar'}
-        >
-          {isMaximized ? (
-            <svg width="10" height="10" viewBox="0 0 10 10">
-              {/* Icono restaurar: dos cuadrados superpuestos */}
-              <rect x="2" y="0" width="8" height="8" fill="none" stroke="currentColor" strokeWidth="1" />
-              <rect x="0" y="2" width="8" height="8" fill="none" stroke="currentColor" strokeWidth="1" />
+    <>
+      <div className={styles.titlebar}>
+        <div className={styles.appInfo}>
+          <span className={styles.appName}>CRIPTA DEL DOGE</span>
+        </div>
+        <div className={styles.controls}>
+          <button
+            className={`${styles.controlBtn} ${styles.helpBtn}`}
+            onClick={() => setIsGuideOpen(true)}
+            title="Guía de la aplicación"
+          >
+            ?
+          </button>
+          <button
+            className={styles.controlBtn}
+            onClick={() => window.api.minimize()}
+            title="Minimizar"
+          >
+            <svg width="10" height="1" viewBox="0 0 10 1">
+              <rect width="10" height="1" fill="currentColor" />
             </svg>
-          ) : (
+          </button>
+          <button
+            className={styles.controlBtn}
+            onClick={() => window.api.maximize()}
+            title={isMaximized ? 'Restaurar' : 'Maximizar'}
+          >
+            {isMaximized ? (
+              <svg width="10" height="10" viewBox="0 0 10 10">
+                <rect x="2" y="0" width="8" height="8" fill="none" stroke="currentColor" strokeWidth="1" />
+                <rect x="0" y="2" width="8" height="8" fill="none" stroke="currentColor" strokeWidth="1" />
+              </svg>
+            ) : (
+              <svg width="10" height="10" viewBox="0 0 10 10">
+                <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" />
+              </svg>
+            )}
+          </button>
+          <button
+            className={`${styles.controlBtn} ${styles.closeBtn}`}
+            onClick={() => window.api.close()}
+            title="Cerrar"
+          >
             <svg width="10" height="10" viewBox="0 0 10 10">
-              <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" />
+              <line x1="0" y1="0" x2="10" y2="10" stroke="currentColor" strokeWidth="1.2" />
+              <line x1="10" y1="0" x2="0" y2="10" stroke="currentColor" strokeWidth="1.2" />
             </svg>
-          )}
-        </button>
-        <button
-          className={`${styles.controlBtn} ${styles.closeBtn}`}
-          onClick={() => window.api.close()}
-          title="Cerrar"
-        >
-          <svg width="10" height="10" viewBox="0 0 10 10">
-            <line x1="0" y1="0" x2="10" y2="10" stroke="currentColor" strokeWidth="1.2" />
-            <line x1="10" y1="0" x2="0" y2="10" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        </button>
+          </button>
+        </div>
       </div>
-    </div>
+      <AppGuide isOpen={isGuideOpen} onClose={() => setIsGuideOpen(false)} />
+    </>
   )
 }


### PR DESCRIPTION
- TitleBar: botón ? con hover en accent, abre AppGuide via isGuideOpen
- AppGuide: panel superpuesto 800px con overlay propio, 4 secciones (Socios, Renovación, Eventos, Calendario) con placeholder 16:9
- Tipografía mixta: font-title solo en el h2 principal, font-main en títulos de sección y descripciones para mantener legibilidad