### PR TITLE
refactor: reducir uso de fuente Minecraft a branding y h1 de página

### DIFF
--- a/criptadoge-app/src/renderer/src/components/Dashboard/Dashboard.module.scss
+++ b/criptadoge-app/src/renderer/src/components/Dashboard/Dashboard.module.scss
@@ -61,10 +61,12 @@
   overflow-x: auto;
 
   h2 {
-    font-family: v.$font-title;
-    font-size: 1.2rem;
+    font-family: v.$font-main;
+    font-weight: 700;
+    font-size: 1rem;
     margin: 0 0 1.5rem 0;
     color: v.$text-main;
+    text-transform: uppercase;
     letter-spacing: 1px;
   }
 }

--- a/criptadoge-app/src/renderer/src/components/EventCalendar/EventCalendar.module.scss
+++ b/criptadoge-app/src/renderer/src/components/EventCalendar/EventCalendar.module.scss
@@ -71,9 +71,10 @@
   }
 
   :global(.fc-toolbar-title) {
-    font-family: v.$font-title;
+    font-family: v.$font-main;
+    font-weight: 700;
     font-size: 1.1rem;
-    letter-spacing: 1px;
+    letter-spacing: 0.5px;
     color: v.$text-main;
   }
 

--- a/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.module.scss
+++ b/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.module.scss
@@ -76,11 +76,12 @@
 
   h1 {
     margin: 1.5rem 0 1rem;
-    font-size: 3rem;
+    font-size: 2.8rem;
     color: v.$text-main;
-    font-family: v.$font-title;
+    font-family: v.$font-main;
+    font-weight: 900;
     line-height: 1.2;
-    letter-spacing: 1px;
+    letter-spacing: 0.5px;
   }
 }
 
@@ -128,8 +129,11 @@
 
   h2 {
     color: v.$text-main;
-    font-family: v.$font-title;
-    font-size: 1.5rem;
+    font-family: v.$font-main;
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
     margin-top: 0;
     margin-bottom: 1.5rem;
     border-bottom: 2px solid v.$color-border;

--- a/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.module.scss
+++ b/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.module.scss
@@ -38,11 +38,14 @@
   @include m.card-base(2rem);
 
   h2 {
-    font-family: v.$font-title;
-    font-size: 2rem;
+    font-family: v.$font-main;
+    font-weight: 700;
+    font-size: 1.6rem;
     margin-bottom: 1.5rem;
     border-bottom: 1px solid v.$color-border;
     padding-bottom: 1rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
   }
 }
 
@@ -171,7 +174,8 @@
 
 .errorMessage {
   color: v.$color-error;
-  font-family: v.$font-title;
+  font-family: v.$font-main;
+  font-weight: 700;
   background-color: rgba(v.$color-error, 0.05);
   border: 1px solid rgba(v.$color-error, 0.3);
   padding: 2rem;

--- a/criptadoge-app/src/renderer/src/components/Modal/Modal.module.scss
+++ b/criptadoge-app/src/renderer/src/components/Modal/Modal.module.scss
@@ -27,7 +27,8 @@
   animation: modalIn 0.2s ease-out forwards;
 
   h3 {
-    font-family: v.$font-title;
+    font-family: v.$font-main;
+    font-weight: 700;
     color: v.$text-main;
     font-size: 1.5rem;
     margin-bottom: 1.5rem;

--- a/criptadoge-app/src/renderer/src/components/StatCard/StatCard.module.scss
+++ b/criptadoge-app/src/renderer/src/components/StatCard/StatCard.module.scss
@@ -28,8 +28,9 @@
 
 .value {
   color: v.$text-main;
-  font-family: v.$font-title;
+  font-family: v.$font-mono;
   font-size: 2.5rem;
+  font-weight: 700;
   margin: 0.5rem 0;
 }
 


### PR DESCRIPTION
Queremos mantener la identidad de marca asique reducimos el uso de la fuente Minecraft

- Minecraft reservado para: TitleBar, sidebar/topBar logo, Login, LoadingScreen y los 4 h1 principales de página
- Modal h3, MemberProfile h2/error, Dashboard h2 sección →  Roboto 700
- StatCard .value → Geist Mono 700 (datos numéricos técnicos)
- EventCalendar fc-toolbar-title → Roboto 700
- EventProfile h1 evento → Roboto 900, h2 sección → Roboto 700 uppercase