### PR TITLE
docs: crear documentación base del proyecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# criptadoge-desktop
+# La Cripta del Doge — App de Gestión
+
+Aplicación de escritorio para la gestión interna del club gaming **La Cripta del Doge**.
+Permite administrar socios, controlar membresías y gestionar eventos del club.
+
+## Stack tecnológico
+
+| Capa | Tecnología |
+|------|-----------|
+| Shell nativo | Electron 39 (frameless window, IPC) |
+| Frontend | React 19 + TypeScript 5 |
+| Estilos | SCSS + CSS Modules + CSS Custom Properties |
+| Build | electron-vite + Vite 7 |
+| Empaquetado | electron-builder |
+| HTTP | Axios (con interceptores de auth) |
+| Routing | React Router 7 (HashRouter) |
+| Calendario | FullCalendar 6 |
+
+## Requisitos previos
+
+- **Node.js** 20 o superior
+- **npm** 10 o superior
+
+## Instalación y desarrollo
+
+```bash
+cd criptadoge-app
+npm install
+npm run dev       # Levanta Electron + renderer en modo desarrollo
+```
+
+> La app se conecta por defecto a `http://localhost:3000`. Asegúrate de tener el backend corriendo.
+
+## Comandos disponibles
+
+| Comando | Descripción |
+|---------|-------------|
+| `npm run dev` | Modo desarrollo (Electron + Vite HMR) |
+| `npm run build` | Typecheck + build de producción |
+| `npm run build:win` | Genera instalador `.exe` para Windows |
+| `npm run build:mac` | Genera `.dmg` para macOS |
+| `npm run build:linux` | Genera AppImage/deb/snap para Linux |
+| `npm run lint` | ESLint |
+| `npm run typecheck` | Comprobación de tipos (node + web) |
+
+## Documentación
+
+- [`docs/ARQUITECTURA.md`](docs/ARQUITECTURA.md) — Arquitectura interna del sistema

--- a/docs/ARQUITECTURA.md
+++ b/docs/ARQUITECTURA.md
@@ -1,0 +1,125 @@
+# Arquitectura — La Cripta del Doge App
+
+## 1. Sistema de Autenticación
+
+### Flujo de login
+1. El usuario introduce credenciales en `Login.tsx`
+2. Se hace `POST /auth/login` al backend
+3. La respuesta devuelve `{ token, user }` que se persiste en `localStorage`:
+   - `cripta_token` — Bearer JWT
+   - `cripta_user` — JSON con `{ id, email, role }`
+
+### Validación de sesión al arrancar
+`AuthContext.tsx` valida la sesión contra el backend en cada inicio de la app:
+
+```
+App monta → AuthProvider.useEffect →
+  localStorage tiene token? → GET /usuarios/:id →
+    OK → setUser + setIsAuthenticated(true)
+    Error → logout() (limpia localStorage)
+  No token → isLoading = false, redirige a /login
+```
+
+### Interceptores Axios (`axiosClient.ts`)
+- **Request interceptor**: añade `Authorization: Bearer <token>` a cada petición
+- **Response interceptor**: en error 401 emite `window.dispatchEvent(new Event('auth:unauthorized'))`
+- `AuthContext` escucha ese evento y llama a `logout()` automáticamente
+
+### Rutas protegidas
+`ProtectedRoute.tsx` bloquea el acceso mientras `isLoading === true` (muestra `LoadingScreen`)
+y redirige a `/login` si `!isAuthenticated`.
+
+---
+
+## 2. Sistema de Temas Dinámicos
+
+> Implementado en la rama `feat/menu-opciones`.
+
+### CSS Custom Properties
+Los colores del sistema se definen como variables CSS nativas en `_variables.scss`:
+
+```css
+:root {
+  --bg-main: #0f172a;         /* tema oscuro (defecto) */
+  --bg-card: #1e293b;
+  --color-primary: #173d8d;
+  /* ... */
+  --bg-card-rgb: 30, 41, 59; /* canales RGB para rgba() */
+}
+
+body.theme-light {
+  --bg-main: #f1f5f9;         /* overrides tema claro */
+  --bg-card: #ffffff;
+  /* ... */
+}
+```
+
+Las variables SCSS son bridges: `$bg-main: var(--bg-main)` — permiten usar la sintaxis SCSS
+habitual en los módulos mientras el valor es dinámico en runtime.
+
+> **Limitación SCSS:** `rgba(v.$color-primary, 0.5)` no funciona cuando la variable SCSS
+> apunta a un `var()`. Solución: usar `rgba(var(--color-primary-rgb), 0.5)` con los canales RGB
+> predefinidos.
+
+### SettingsContext (`context/SettingsContext.tsx`)
+Gestiona tema y autoStart de forma reactiva:
+
+```typescript
+setTheme('light') →
+  localStorage.setItem('cripta_theme', 'light')
+  document.body.classList.add('theme-light')  // activa los overrides CSS
+```
+
+El estado inicial se lee de `localStorage`. La clase en `body` es el único punto de control
+del tema — todos los componentes responden automáticamente sin re-renderizados.
+
+---
+
+## 3. Comunicación con la API Nativa de Electron (IPC)
+
+La ventana es frameless (`frame: false`), por lo que los controles y la comunicación nativa
+se implementan vía IPC seguro a través del Context Bridge.
+
+### Arquitectura de capas
+
+```
+Renderer (React)           Preload (Context Bridge)      Main Process (Electron)
+──────────────────         ───────────────────────────   ───────────────────────
+window.api.minimize()  →   ipcRenderer.send('...')    →  ipcMain.on('window-minimize')
+window.api.maximize()  →   ipcRenderer.send('...')    →  ipcMain.on('window-maximize')
+window.api.close()     →   ipcRenderer.send('...')    →  ipcMain.on('window-close')
+
+window.api.getAutoStart() → ipcRenderer.invoke('get-autostart') → ipcMain.handle → app.getLoginItemSettings()
+window.api.setAutoStart() → ipcRenderer.invoke('set-autostart') → ipcMain.handle → app.setLoginItemSettings()
+
+                        ←   ipcRenderer.on('window-maximized') ← mainWindow.webContents.send(...)
+```
+
+### Patrones IPC
+
+| Patrón | Cuándo usarlo | Ejemplo |
+|--------|---------------|---------|
+| `ipcMain.on` + `ipcRenderer.send` | Fire & forget, sin respuesta | Controles de ventana |
+| `ipcMain.handle` + `ipcRenderer.invoke` | Request/response async | `getAutoStart` |
+| `webContents.send` + `ipcRenderer.on` | Push desde main → renderer | Estado maximizado |
+
+### API expuesta (`window.api`)
+Definida en `src/preload/index.ts` y tipada en `src/preload/index.d.ts`:
+
+```typescript
+window.api = {
+  minimize: () => void
+  maximize: () => void
+  close: () => void
+  onMaximizeChange: (cb: (isMaximized: boolean) => void) => void
+  setAutoStart: (enable: boolean) => Promise<void>   // feat/menu-opciones
+  getAutoStart: () => Promise<boolean>               // feat/menu-opciones
+}
+```
+
+### Auto-arranque con el sistema
+`app.setLoginItemSettings({ openAtLogin: true/false })` registra/elimina la entrada
+en el registro de Windows (`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`),
+LaunchAgents en macOS, o XDG autostart en Linux.
+Al arrancar la app, `SettingsContext` consulta el estado real del SO con `getAutoStart()`
+y lo usa como fuente de verdad (en lugar de `localStorage`).


### PR DESCRIPTION
- README.md: descripción del proyecto, stack tecnológico, instrucciones de instalación y tabla de comandos disponibles
- docs/ARQUITECTURA.md: documenta sistema de autenticación (flujo de login, validación al arrancar, interceptores Axios, rutas protegidas), sistema de temas dinámicos (CSS Custom Properties, SettingsContext) e IPC con Electron (Context Bridge, patrones IPC, auto-arranque nativo)