### PR TITLE
fix: bloquear acceso al panel a usuarios sin rol ADMIN

### DIFF
--- a/criptadoge-app/src/renderer/src/App.routes.tsx
+++ b/criptadoge-app/src/renderer/src/App.routes.tsx
@@ -30,7 +30,7 @@ export const AppRoutes: React.FC = () => {
       <Routes>
         <Route path="/login" element={<Login />} />
 
-        <Route element={<ProtectedRoute />}>
+        <Route element={<ProtectedRoute allowedRoles={['ADMIN']} />}>
           <Route path="/" element={<Layout />}>
             <Route index element={<Dashboard />} />
             <Route path="socios" element={<UsersList />} />

--- a/criptadoge-app/src/renderer/src/components/Login/Login.tsx
+++ b/criptadoge-app/src/renderer/src/components/Login/Login.tsx
@@ -44,6 +44,12 @@ export const Login: React.FC = () => {
         localStorage.removeItem('cripta_remembered_email')
       }
 
+      if (response.data.user?.role !== 'ADMIN') {
+        setErrorMessage('No tienes permisos para acceder al panel de administración.')
+        setShowErrorModal(true)
+        return
+      }
+
       login(response.data.access_token, response.data.user)
       navigate('/')
     } catch (error: any) {


### PR DESCRIPTION
- Login.tsx: verificar role === 'ADMIN' antes de llamar a login(), mostrando modal de error si el usuario autenticado no es admin
- App.routes.tsx: pasar allowedRoles={['ADMIN']} a ProtectedRoute como segunda capa de defensa contra manipulación de localStorage