### PR TITLE
fix: eliminar funciones SCSS incompatibles con CSS Custom Properties

### DIFF
--- a/criptadoge-app/src/renderer/src/components/AppGuide/AppGuide.module.scss
+++ b/criptadoge-app/src/renderer/src/components/AppGuide/AppGuide.module.scss
@@ -21,7 +21,7 @@
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(v.$color-primary, 0.15);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(var(--color-primary-rgb), 0.15);
   animation: guideIn 0.2s ease-out forwards;
 }
 
@@ -55,7 +55,7 @@
   transition: background-color 0.15s, color 0.15s;
 
   &:hover {
-    background-color: rgba(v.$color-error, 0.15);
+    background-color: rgba(var(--color-error-rgb), 0.15);
     color: v.$color-error;
   }
 }
@@ -93,7 +93,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: inset 0 0 20px rgba(v.$color-primary, 0.08);
+  box-shadow: inset 0 0 20px rgba(var(--color-primary-rgb), 0.08);
 }
 
 .videoPlaceholderText {

--- a/criptadoge-app/src/renderer/src/components/EventMaker/EventMaker.module.scss
+++ b/criptadoge-app/src/renderer/src/components/EventMaker/EventMaker.module.scss
@@ -21,7 +21,7 @@
     @include m.form-input;
 
     &:focus {
-      box-shadow: 0 0 0 2px rgba(v.$color-primary, 0.2);
+      box-shadow: 0 0 0 2px rgba(var(--color-primary-rgb), 0.2);
     }
 
     &:disabled {
@@ -73,7 +73,7 @@
   @include m.btn-primary;
 
   &:hover:not(:disabled) {
-    background-color: rgba(v.$color-primary, 0.8);
+    background-color: rgba(var(--color-primary-rgb), 0.8);
   }
 }
 

--- a/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.module.scss
+++ b/criptadoge-app/src/renderer/src/components/EventProfile/EventProfile.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/variables' as v;
-@use 'sass:color';
 @use '../../styles/mixins' as m;
 @use '../../styles/labels' as l;
 
@@ -167,18 +166,18 @@
   display: inline-flex;
   align-items: center;
   padding: 1rem 1.5rem;
-  background: rgba(v.$color-accent, 0.1);
+  background: rgba(var(--color-accent-rgb), 0.1);
   color: v.$color-accent;
   border-radius: 12px;
   font-size: 1.1rem;
-  border: 1px solid rgba(v.$color-accent, 0.3);
+  border: 1px solid rgba(var(--color-accent-rgb), 0.3);
   font-family: v.$font-mono;
 
   strong {
     margin-left: 0.5rem;
     text-transform: uppercase;
     font-weight: 800;
-    color: color.adjust(v.$color-accent, $lightness: 15%);
+    color: v.$color-accent;
   }
 }
 
@@ -196,8 +195,8 @@
     color 0.2s;
 
   &:hover {
-    background-color: rgba(v.$color-primary, 0.1);
-    color: color.adjust(v.$color-primary, $lightness: 50%);
+    background-color: rgba(var(--color-primary-rgb), 0.1);
+    color: v.$text-main;
   }
 }
 
@@ -207,7 +206,7 @@
   font-family: v.$font-main;
 
   &:hover {
-    color: color.adjust(v.$color-error, $lightness: 30%);
+    color: v.$text-main;
   }
 }
 

--- a/criptadoge-app/src/renderer/src/components/LoadingScreen/LoadingScreen.module.scss
+++ b/criptadoge-app/src/renderer/src/components/LoadingScreen/LoadingScreen.module.scss
@@ -10,7 +10,7 @@
 .spinner {
   width: 50px;
   height: 50px;
-  border: 4px solid rgba(v.$color-primary, 0.2);
+  border: 4px solid rgba(var(--color-primary-rgb), 0.2);
   border-left-color: v.$color-primary;
   border-radius: 50%;
   animation: spin 1s linear infinite;

--- a/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.module.scss
+++ b/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/variables' as v;
-@use 'sass:color';
 @use '../../styles/mixins' as m;
 
 .container {
@@ -78,7 +77,7 @@
   padding: 1.5rem;
   font-size: 1.1rem;
   transition: opacity 0.2s;
-  box-shadow: 0 4px 12px rgba(v.$color-primary, 0.3);
+  box-shadow: 0 4px 12px rgba(var(--color-primary-rgb), 0.3);
 
   &:hover:not(:disabled) {
     opacity: 0.9;
@@ -129,17 +128,17 @@
 }
 
 .activo {
-  background-color: rgba(v.$color-accent, 0.15);
+  background-color: rgba(var(--color-accent-rgb), 0.15);
   color: v.$color-accent;
 }
 
 .inactivo {
-  background-color: rgba(v.$color-error, 0.15);
+  background-color: rgba(var(--color-error-rgb), 0.15);
   color: v.$color-error;
 }
 
 .pendiente {
-  background-color: rgba(v.$text-muted, 0.15);
+  background-color: rgba(var(--text-muted-rgb), 0.15);
   color: v.$text-muted;
 }
 
@@ -176,12 +175,12 @@
   color: v.$color-error;
   font-family: v.$font-main;
   font-weight: 700;
-  background-color: rgba(v.$color-error, 0.05);
-  border: 1px solid rgba(v.$color-error, 0.3);
+  background-color: rgba(var(--color-error-rgb), 0.05);
+  border: 1px solid rgba(var(--color-error-rgb), 0.3);
   padding: 2rem;
   border-radius: 8px;
   text-align: center;
-  box-shadow: 0 0 15px rgba(v.$color-error, 0.1);
+  box-shadow: 0 0 15px rgba(var(--color-error-rgb), 0.1);
   letter-spacing: 1px;
 }
 
@@ -191,7 +190,7 @@
   margin-top: 0.3rem;
   border-radius: 6px;
   border: 1px solid v.$color-border;
-  background-color: rgba(v.$bg-main, 0.8);
+  background-color: rgba(var(--bg-main-rgb), 0.8);
   color: v.$text-main;
   font-family: v.$font-main;
   font-size: 0.95rem;
@@ -200,7 +199,7 @@
 
   &:focus {
     border-color: v.$color-primary;
-    box-shadow: 0 0 8px rgba(v.$color-primary, 0.3);
+    box-shadow: 0 0 8px rgba(var(--color-primary-rgb), 0.3);
   }
 }
 
@@ -217,16 +216,16 @@
 }
 
 .roleAdmin {
-  background-color: rgba(v.$color-accent, 0.15);
+  background-color: rgba(var(--color-accent-rgb), 0.15);
   color: v.$color-accent;
-  border-color: rgba(v.$color-accent, 0.4);
-  box-shadow: 0 0 10px rgba(v.$color-accent, 0.2);
+  border-color: rgba(var(--color-accent-rgb), 0.4);
+  box-shadow: 0 0 10px rgba(var(--color-accent-rgb), 0.2);
 }
 
 .roleMember {
-  background-color: rgba(v.$color-primary, 0.2);
-  color: color.adjust(v.$color-primary, $lightness: 25%);
-  border-color: rgba(v.$color-primary, 0.3);
+  background-color: rgba(var(--color-primary-rgb), 0.2);
+  color: v.$text-main;
+  border-color: rgba(var(--color-primary-rgb), 0.3);
 }
 
 .modalDeleteBtn {
@@ -240,7 +239,7 @@
   text-transform: uppercase;
 
   &:hover {
-    background-color: color.adjust(v.$color-error, $lightness: -10%);
+    background-color: #c53030; /* static - color.adjust incompatible con CSS vars */
   }
 }
 
@@ -255,7 +254,7 @@
   transition: background-color 0.2s;
 
   &:hover {
-    background-color: rgba(v.$text-main, 0.07);
+    background-color: rgba(var(--text-main-rgb), 0.07);
   }
 }
 

--- a/criptadoge-app/src/renderer/src/components/MemberRow/MemberRow.module.scss
+++ b/criptadoge-app/src/renderer/src/components/MemberRow/MemberRow.module.scss
@@ -6,17 +6,17 @@
 }
 
 .activo {
-  background-color: rgba(v.$color-accent, 0.15);
+  background-color: rgba(var(--color-accent-rgb), 0.15);
   color: v.$color-accent;
 }
 
 .inactivo {
-  background-color: rgba(v.$color-error, 0.15);
+  background-color: rgba(var(--color-error-rgb), 0.15);
   color: v.$color-error;
 }
 
 .pendiente {
-  background-color: rgba(v.$text-muted, 0.15);
+  background-color: rgba(var(--text-muted-rgb), 0.15);
   color: v.$text-muted;
 }
 

--- a/criptadoge-app/src/renderer/src/components/SettingsModal/SettingsModal.module.scss
+++ b/criptadoge-app/src/renderer/src/components/SettingsModal/SettingsModal.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/variables' as v;
-@use 'sass:color';
 
 .settingsSection {
   display: flex;
@@ -44,13 +43,13 @@
   transition: all 0.2s;
 
   &:hover:not(.active) {
-    border-color: color.adjust(v.$color-border, $lightness: 10%);
+    border-color: rgba(var(--color-border-rgb), 0.8);
     color: v.$text-main;
   }
 
   &.active {
     border-color: v.$color-primary;
-    background-color: rgba(v.$color-primary, 0.25);
+    background-color: rgba(var(--color-primary-rgb), 0.25);
     color: v.$text-main;
     font-weight: 600;
   }
@@ -99,7 +98,7 @@
     }
 
     &:focus + .slider {
-      box-shadow: 0 0 0 2px rgba(v.$color-primary, 0.4);
+      box-shadow: 0 0 0 2px rgba(var(--color-primary-rgb), 0.4);
     }
   }
 }

--- a/criptadoge-app/src/renderer/src/components/TitleBar/TitleBar.module.scss
+++ b/criptadoge-app/src/renderer/src/components/TitleBar/TitleBar.module.scss
@@ -46,7 +46,7 @@
   transition: background-color 0.15s, color 0.15s;
 
   &:hover {
-    background-color: rgba(v.$text-main, 0.1);
+    background-color: rgba(var(--text-main-rgb), 0.1);
     color: v.$text-main;
   }
 }
@@ -62,7 +62,7 @@
   color: v.$text-muted;
 
   &:hover {
-    background-color: rgba(v.$color-accent, 0.15);
+    background-color: rgba(var(--color-accent-rgb), 0.15);
     color: v.$color-accent;
   }
 }
@@ -76,7 +76,7 @@
   margin-right: 0.25rem;
 
   &:hover {
-    background-color: rgba(v.$color-accent, 0.15);
+    background-color: rgba(var(--color-accent-rgb), 0.15);
     color: v.$color-accent;
   }
 }

--- a/criptadoge-app/src/renderer/src/components/UsersList/UsersList.module.scss
+++ b/criptadoge-app/src/renderer/src/components/UsersList/UsersList.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/variables' as v;
-@use 'sass:color';
 @use '../../styles/mixins' as m;
 
 .container {
@@ -58,17 +57,17 @@
 }
 
 .activo {
-  background-color: rgba(v.$color-accent, 0.15);
+  background-color: rgba(var(--color-accent-rgb), 0.15);
   color: v.$color-accent;
 }
 
 .inactivo {
-  background-color: rgba(v.$color-error, 0.15);
+  background-color: rgba(var(--color-error-rgb), 0.15);
   color: v.$color-error;
 }
 
 .pendiente {
-  background-color: rgba(v.$text-muted, 0.15);
+  background-color: rgba(var(--text-muted-rgb), 0.15);
   color: v.$text-muted;
 }
 
@@ -145,11 +144,11 @@
       transition: all 0.2s;
 
       &:focus {
-        box-shadow: 0 0 8px rgba(v.$color-primary, 0.3);
+        box-shadow: 0 0 8px rgba(var(--color-primary-rgb), 0.3);
       }
 
       &::placeholder {
-        color: rgba(v.$text-muted, 0.5);
+        color: rgba(var(--text-muted-rgb), 0.5);
       }
     }
 
@@ -167,8 +166,8 @@
     margin-top: 0.5rem;
 
     &:hover {
-      background-color: color.adjust(v.$color-primary, $lightness: 10%);
-      box-shadow: 0 0 15px rgba(v.$color-primary, 0.4);
+      background-color: v.$color-primary;
+      box-shadow: 0 0 15px rgba(var(--color-primary-rgb), 0.4);
     }
   }
 }

--- a/criptadoge-app/src/renderer/src/styles/_variables.scss
+++ b/criptadoge-app/src/renderer/src/styles/_variables.scss
@@ -14,10 +14,12 @@
   --color-success:    #10b981;
 
   // Canales RGB para uso en rgba() en CSS puro
+  --bg-main-rgb:         15, 23, 42;
   --bg-card-rgb:         30, 41, 59;
   --color-primary-rgb:   23, 61, 141;
   --color-border-rgb:    51, 65, 85;
   --text-main-rgb:       248, 250, 252;
+  --text-muted-rgb:      148, 163, 184;
   --color-error-rgb:     239, 68, 68;
   --color-accent-rgb:    234, 179, 8;
 }
@@ -34,10 +36,12 @@ body.theme-light {
   --color-error:      #dc2626;
   --color-success:    #059669;
 
+  --bg-main-rgb:         241, 245, 249;
   --bg-card-rgb:         255, 255, 255;
   --color-primary-rgb:   29, 78, 216;
   --color-border-rgb:    226, 232, 240;
   --text-main-rgb:       15, 23, 42;
+  --text-muted-rgb:      100, 116, 139;
   --color-error-rgb:     220, 38, 38;
   --color-accent-rgb:    180, 83, 9;
 }


### PR DESCRIPTION
- _variables.scss: añadir --text-muted-rgb y --bg-main-rgb (dark/light)
- Eliminar color.adjust() en EventProfile, MemberProfile, UsersList y SettingsModal; sustituir por variables semánticas (v.$text-main, v.$color-accent, v.$color-primary) o valor estático comentado
- Reemplazar rgba(v.$var, x) por rgba(var(--*-rgb), x) en 10 archivos
- Eliminar @use 'sass:color' en los 4 archivos donde ya no se usa