### PR TITLE
Integrar mensajes de contacto en el panel de administración

### DIFF
--- a/criptadoge-app/src/renderer/src/App.routes.tsx
+++ b/criptadoge-app/src/renderer/src/App.routes.tsx
@@ -23,6 +23,11 @@ const EventProfile = lazy(() =>
 const EventCalendar = lazy(() =>
   import('./components/EventCalendar/EventCalendar').then((m) => ({ default: m.EventCalendar }))
 )
+const ContactMessages = lazy(() =>
+  import('./components/ContactMessages/ContactMessages').then((m) => ({
+    default: m.ContactMessages
+  }))
+)
 
 export const AppRoutes: React.FC = () => {
   return (
@@ -38,6 +43,7 @@ export const AppRoutes: React.FC = () => {
             <Route path="eventos" element={<EventList />} />
             <Route path="eventos/:id" element={<EventProfile />} />
             <Route path="calendario" element={<EventCalendar />} />
+            <Route path="contacto" element={<ContactMessages />} />
           </Route>
         </Route>
 

--- a/criptadoge-app/src/renderer/src/api/contactMessagesApi.ts
+++ b/criptadoge-app/src/renderer/src/api/contactMessagesApi.ts
@@ -1,0 +1,43 @@
+import { apiClient } from './axiosClient'
+
+export interface ContactMessage {
+  id: string
+  nombre: string
+  email: string
+  asunto: string
+  mensaje: string
+  estado: string
+  createdAt: string
+  updatedAt: string
+}
+
+type RawContactMessage = Partial<ContactMessage> & {
+  _id?: string
+}
+
+type ContactMessagesResponse =
+  | RawContactMessage[]
+  | {
+      items?: RawContactMessage[]
+      data?: RawContactMessage[]
+    }
+
+const normalizeContactMessage = (message: RawContactMessage): ContactMessage => ({
+  id: message.id ?? message._id ?? '',
+  nombre: message.nombre ?? '',
+  email: message.email ?? '',
+  asunto: message.asunto ?? '',
+  mensaje: message.mensaje ?? '',
+  estado: message.estado ?? 'pendiente',
+  createdAt: message.createdAt ?? '',
+  updatedAt: message.updatedAt ?? ''
+})
+
+export const getContactMessages = async (): Promise<ContactMessage[]> => {
+  const { data } = await apiClient.get<ContactMessagesResponse>('/contacto')
+  const messages = Array.isArray(data) ? data : (data?.items ?? data?.data ?? [])
+
+  return messages
+    .map(normalizeContactMessage)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+}

--- a/criptadoge-app/src/renderer/src/components/ContactMessages/ContactMessages.module.scss
+++ b/criptadoge-app/src/renderer/src/components/ContactMessages/ContactMessages.module.scss
@@ -1,0 +1,260 @@
+@use '../../styles/variables' as v;
+@use '../../styles/mixins' as m;
+
+.container {
+  background-color: v.$bg-main;
+  color: v.$text-main;
+  font-family: v.$font-main;
+  height: 100%;
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid v.$color-border;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    width: 60px;
+    height: 2px;
+    background: v.$color-accent;
+  }
+
+  h1 {
+    font-family: v.$font-title;
+    color: v.$text-main;
+    font-size: 2rem;
+    margin: 0 0 0.5rem 0;
+  }
+
+  p {
+    color: v.$text-muted;
+    font-size: 0.9rem;
+    margin: 0;
+  }
+}
+
+.card {
+  @include m.card-base;
+  overflow-x: auto;
+}
+
+.toolbar {
+  margin-bottom: 1.5rem;
+  display: flex;
+}
+
+.searchInput {
+  width: 100%;
+  max-width: 440px;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  border: 1px solid v.$color-border;
+  background-color: v.$bg-main;
+  color: v.$text-main;
+  font-family: v.$font-main;
+  font-size: 0.95rem;
+  outline: none;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  &:focus {
+    border-color: v.$color-primary;
+    box-shadow: 0 0 8px rgba(var(--color-primary-rgb), 0.25);
+  }
+
+  &::placeholder {
+    color: v.$text-muted;
+  }
+}
+
+.table {
+  @include m.table-base;
+  table-layout: fixed;
+
+  th {
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
+  }
+
+  td {
+    color: v.$text-main;
+    font-size: 0.9rem;
+    vertical-align: top;
+  }
+
+  th:nth-child(1),
+  td:nth-child(1) {
+    width: 14%;
+  }
+
+  th:nth-child(2),
+  td:nth-child(2) {
+    width: 20%;
+  }
+
+  th:nth-child(3),
+  td:nth-child(3) {
+    width: 16%;
+  }
+
+  th:nth-child(4),
+  td:nth-child(4) {
+    width: 28%;
+  }
+
+  th:nth-child(5),
+  td:nth-child(5) {
+    width: 11%;
+  }
+
+  th:nth-child(6),
+  td:nth-child(6) {
+    width: 11%;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.subjectCell,
+.messageCell {
+  overflow-wrap: anywhere;
+}
+
+.messageCell {
+  color: v.$text-muted;
+  line-height: 1.45;
+}
+
+.emailLink {
+  color: v.$color-accent;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.badge {
+  @include m.badge-base;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.pending {
+  background-color: rgba(var(--color-primary-rgb), 0.18);
+  color: v.$text-main;
+  border: 1px solid rgba(var(--color-primary-rgb), 0.45);
+}
+
+.resolved {
+  background-color: rgba(var(--color-success-rgb), 0.16);
+  color: v.$color-success;
+}
+
+.neutral {
+  background-color: rgba(var(--text-muted-rgb), 0.15);
+  color: v.$text-muted;
+}
+
+.statusMessage {
+  text-align: center;
+  padding: 3rem 0 !important;
+  color: v.$text-muted;
+  font-style: italic;
+}
+
+.errorMessage {
+  color: v.$color-error;
+}
+
+@media (max-width: 920px) {
+  .table {
+    min-width: 860px;
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .header {
+    h1 {
+      font-size: 1.5rem;
+    }
+  }
+
+  .toolbar {
+    .searchInput {
+      max-width: 100%;
+    }
+  }
+}
+
+@media (max-width: 560px) {
+  .card {
+    padding: 0.75rem;
+  }
+
+  .table,
+  .table thead,
+  .table tbody,
+  .table tr,
+  .table th,
+  .table td {
+    display: block;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .table {
+    table-layout: auto;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .table tbody tr {
+    border: 1px solid v.$color-border;
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+    padding: 1rem;
+    background-color: v.$bg-card;
+  }
+
+  .table tbody td {
+    border: none;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid rgba(var(--color-border-rgb), 0.4);
+
+    &::before {
+      content: attr(data-label);
+      display: block;
+      margin-bottom: 0.25rem;
+      color: v.$text-muted;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}

--- a/criptadoge-app/src/renderer/src/components/ContactMessages/ContactMessages.tsx
+++ b/criptadoge-app/src/renderer/src/components/ContactMessages/ContactMessages.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import styles from './ContactMessages.module.scss'
+import { ContactMessage, getContactMessages } from '../../api/contactMessagesApi'
+
+const formatDate = (value: string): string => {
+  if (!value) return 'Sin fecha'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Sin fecha'
+
+  return new Intl.DateTimeFormat('es-ES', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(date)
+}
+
+const getStatusClass = (estado: string): string => {
+  const normalized = estado.toLowerCase()
+
+  if (normalized === 'pendiente') return styles.pending
+  if (normalized === 'resuelto' || normalized === 'respondido') return styles.resolved
+  return styles.neutral
+}
+
+export const ContactMessages: React.FC = () => {
+  const [messages, setMessages] = useState<ContactMessage[]>([])
+  const [searchTerm, setSearchTerm] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchMessages = async (): Promise<void> => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        const data = await getContactMessages()
+        setMessages(data)
+      } catch (err) {
+        console.error('Error al cargar mensajes de contacto:', err)
+        setError('No se pudieron cargar los mensajes de contacto.')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchMessages()
+  }, [])
+
+  const filteredMessages = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase()
+    if (!term) return messages
+
+    return messages.filter((message) =>
+      [message.nombre, message.email, message.asunto, message.mensaje, message.estado].some(
+        (value) => value.toLowerCase().includes(term)
+      )
+    )
+  }, [messages, searchTerm])
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <div>
+          <h1>MENSAJES DE CONTACTO</h1>
+          <p>Solicitudes recibidas desde el formulario publico</p>
+        </div>
+      </header>
+
+      <div className={styles.card}>
+        <div className={styles.toolbar}>
+          <input
+            type="text"
+            placeholder="Buscar por nombre, email, asunto o estado..."
+            className={styles.searchInput}
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+          />
+        </div>
+
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Nombre</th>
+              <th>Email</th>
+              <th>Asunto</th>
+              <th>Mensaje</th>
+              <th>Estado</th>
+              <th>Recibido</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={6} className={styles.statusMessage}>
+                  Cargando mensajes de contacto...
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={6} className={`${styles.statusMessage} ${styles.errorMessage}`}>
+                  {error}
+                </td>
+              </tr>
+            ) : filteredMessages.length > 0 ? (
+              filteredMessages.map((message) => (
+                <tr key={message.id}>
+                  <td data-label="Nombre">{message.nombre}</td>
+                  <td data-label="Email">
+                    <a href={`mailto:${message.email}`} className={styles.emailLink}>
+                      {message.email}
+                    </a>
+                  </td>
+                  <td data-label="Asunto" className={styles.subjectCell}>
+                    {message.asunto}
+                  </td>
+                  <td data-label="Mensaje" className={styles.messageCell}>
+                    {message.mensaje}
+                  </td>
+                  <td data-label="Estado">
+                    <span className={`${styles.badge} ${getStatusClass(message.estado)}`}>
+                      {message.estado}
+                    </span>
+                  </td>
+                  <td data-label="Recibido">{formatDate(message.createdAt)}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={6} className={styles.statusMessage}>
+                  {searchTerm
+                    ? `No se han encontrado mensajes con "${searchTerm}"`
+                    : 'No hay mensajes de contacto registrados.'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/criptadoge-app/src/renderer/src/components/Dashboard/Dashboard.tsx
+++ b/criptadoge-app/src/renderer/src/components/Dashboard/Dashboard.tsx
@@ -33,15 +33,9 @@ export const Dashboard: React.FC = () => {
   }, [])
 
   const totalMembers = members.length
-  const activeMembers = members.filter(
-    (m) => getMemberStatus(m) === 'Activo'
-  ).length
-  const pendingMembers = members.filter(
-    (m) => getMemberStatus(m) === 'Pendiente'
-  ).length
-  const inactiveMembers = members.filter(
-    (m) => getMemberStatus(m) === 'Inactivo'
-  ).length
+  const activeMembers = members.filter((m) => getMemberStatus(m) === 'Activo').length
+  const pendingMembers = members.filter((m) => getMemberStatus(m) === 'Pendiente').length
+  const inactiveMembers = members.filter((m) => getMemberStatus(m) === 'Inactivo').length
 
   const today = new Date()
   today.setHours(0, 0, 0, 0)
@@ -54,7 +48,7 @@ export const Dashboard: React.FC = () => {
   }).length
 
   const latestRenewals = [...members]
-    .sort((a, b) => new Date(b.lastRenewal).getTime() - new Date(a.lastRenewal).getTime())
+    .sort((a, b) => new Date(b.lastRenewal ?? 0).getTime() - new Date(a.lastRenewal ?? 0).getTime())
     .slice(0, 3)
 
   if (isLoading) return <div className={styles.statusMessage}>Cargando datos del servidor...</div>

--- a/criptadoge-app/src/renderer/src/components/Layout/Layout.tsx
+++ b/criptadoge-app/src/renderer/src/components/Layout/Layout.tsx
@@ -70,6 +70,15 @@ export const Layout: React.FC = () => {
           >
             Calendario
           </NavLink>
+          <NavLink
+            to="/contacto"
+            onClick={closeMenu}
+            className={({ isActive }) =>
+              isActive ? `${styles.navLink} ${styles.active}` : styles.navLink
+            }
+          >
+            Contacto
+          </NavLink>
         </nav>
 
         <div className={styles.logoutWrapper}>

--- a/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.tsx
+++ b/criptadoge-app/src/renderer/src/components/MemberProfile/MemberProfile.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import styles from './MemberProfile.module.scss'
-import { Member, getMemberStatus } from '../../data/members'
+import { getMemberStatus } from '../../data/members'
 import { Modal } from '../Modal/Modal'
 import { apiClient } from '../../api/axiosClient'
 
@@ -259,7 +259,11 @@ export const MemberProfile: React.FC = () => {
                 className={styles.renewBtn}
                 onClick={() => setShowRenewModal(true)}
                 disabled={!member.dni || member.dni.trim() === ''}
-                title={!member.dni || member.dni.trim() === '' ? 'El socio debe tener un DNI registrado para poder renovar' : undefined}
+                title={
+                  !member.dni || member.dni.trim() === ''
+                    ? 'El socio debe tener un DNI registrado para poder renovar'
+                    : undefined
+                }
               >
                 Renovar Membresía
                 <span className={styles.renewSubtext}>Cargar 1 Mes</span>
@@ -307,8 +311,8 @@ export const MemberProfile: React.FC = () => {
         title="¡ATENCIÓN! DESACTIVAR SOCIO"
       >
         <p className={styles.modalText}>
-          Estás a punto de desactivar a{' '}
-          <strong style={{ color: '#ef4444' }}>{member.name}</strong>.<br />
+          Estás a punto de desactivar a <strong style={{ color: '#ef4444' }}>{member.name}</strong>.
+          <br />
           ¿Estás seguro?
         </p>
         <div className={styles.modalActions}>

--- a/docs/ARQUITECTURA.md
+++ b/docs/ARQUITECTURA.md
@@ -208,3 +208,32 @@ VITE_API_URL=http://<IP-del-servidor>:<puerto>
 
 > La carpeta `android/` está en `.gitignore` — se regenera localmente con `npx cap add android`
 > tras clonar el repositorio.
+
+---
+
+## 5. Mensajes de contacto
+
+El formulario publico de contacto crea mensajes mediante `POST /contacto` en el backend NestJS,
+o `POST /api/contacto` cuando se accede a traves de Nginx. No requiere autenticacion y recibe:
+
+```json
+{
+  "nombre": "string",
+  "email": "email valido",
+  "asunto": "string",
+  "mensaje": "string"
+}
+```
+
+Todos los campos son obligatorios y `email` debe tener formato valido. Si la peticion es correcta,
+el backend responde `201 Created` con el mensaje guardado en MongoDB, incluyendo `_id`,
+`estado: "pendiente"`, `createdAt` y `updatedAt`.
+
+La vista de administracion `#/contacto` usa el cliente Axios protegido para solicitar `GET /contacto`.
+Este endpoint de lectura esta protegido para administradores con el patron `JwtAuthGuard`,
+`RolesGuard` y `@Roles('ADMIN')`, y devuelve los mensajes guardados en MongoDB.
+
+El frontend muestra los mensajes ordenados de mas reciente a mas antiguo y normaliza tanto respuestas
+en array como respuestas paginadas con `items` o `data`.
+
+Actualmente el flujo de contacto no envia emails; solo persiste el mensaje en MongoDB.


### PR DESCRIPTION
## Objetivo
Añadir en la aplicación de escritorio una vista de administración para consultar los mensajes recibidos desde el formulario de contacto, consumiendo el endpoint protegido `GET /contacto` y manteniendo la coherencia visual con el resto del panel.

## Cambios principales
* Se añade la ruta `#/contacto` en el router de la aplicación y el acceso desde el menú lateral.
* Se crea un cliente API específico para mensajes de contacto con normalización de respuestas en array o paginadas.
* Se implementa una vista de listado con búsqueda, orden por fecha descendente, estados de carga/error/vacío y badges de estado.
* Se ajustan pequeñas piezas del dashboard y del perfil de socio para mantener compilación y tipado coherentes tras la integración.
* Se actualiza `docs/ARQUITECTURA.md` para documentar el flujo de contacto y el contrato esperado del endpoint.

## UI / UX (Solo si aplica)
* Se reutilizan los tokens y mixins existentes del tema para tabla, badges, bordes y colores de estado.
* La vista nueva respeta el patrón visual del panel y adapta el listado a escritorio y móvil.

## Changelog
* `docs/ARQUITECTURA.md`

## Testing
* `npm run build` ejecutado con éxito.
* Validación manual del flujo de renderizado y compilación de la nueva ruta y componentes asociados.